### PR TITLE
feat: new util functions to un/archive and rename repos from the cli

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "tmpl"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@
 - p6_github_util_pr_create(user, reviewer)
 - p6_github_util_pr_merge_last()
 - p6_github_util_pr_submit(editor, user, tmpl, [reviewer=], [cli_msg=], [pr_num=])
+- p6_github_util_repo_archive()
+- p6_github_util_repo_patch(state)
+- p6_github_util_repo_rename(orig_org_repo, new_org_repo)
+- p6_github_util_repo_rename_strip_leading_underscores(orig_org_repo, org, repo)
+- p6_github_util_repo_unarchive()
 
 ## Hierarchy
 

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -110,3 +110,102 @@ p6_github_util_pr_create() {
 
     p6_return_void
 }
+
+######################################################################
+#<
+#
+# Function: p6_github_util_repo_patch(state)
+#
+#  Args:
+#	state -
+#
+#  Environment:	 PATCH
+#>
+######################################################################
+p6_github_util_repo_patch() {
+    local state="$1"
+
+     echo gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/:owner/:repo -f archived=$state
+     gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/:owner/:repo -f archived=$state
+
+    p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6_github_util_repo_archive()
+#
+#>
+######################################################################
+p6_github_util_repo_archive() {
+
+  p6_github_util_repo_patch "true"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6_github_util_repo_unarchive()
+#
+#>
+######################################################################
+p6_github_util_repo_unarchive() {
+
+  p6_github_util_repo_patch "false"
+
+  p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6_github_util_repo_rename(orig_org_repo, new_org_repo)
+#
+#  Args:
+#	orig_org_repo -
+#	new_org_repo -
+#
+#  Environment:	 PATCH
+#>
+######################################################################
+p6_github_util_repo_rename() {
+    local orig_org_repo="$1"
+    local new_org_repo="$2"
+
+    echo  gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/"$orig_org_repo" -f name="${new_org_repo#*/}"
+    gh api --method PATCH -H "Accept: application/vnd.github+json" /repos/"$orig_org_repo" -f name="${new_org_repo#*/}"
+
+    p6_return_void
+}
+
+######################################################################
+#<
+#
+# Function: p6_github_util_repo_rename_strip_leading_underscores(orig_org_repo, org, repo)
+#
+#  Args:
+#	orig_org_repo -
+#	org -
+#	repo -
+#
+#>
+######################################################################
+p6_github_util_repo_rename_strip_leading_underscores() {
+    local orig_org_repo="$1"
+
+    local org="${orig_org_repo%%/*}"
+    local repo="${orig_org_repo#*/}"
+    local new_repo
+
+    new_repo="$(echo "$repo" | sed 's/^_*\(.*\)/\1/')"
+
+    if [ "$repo" != "$new_repo" ]; then
+        local new_org_repo="${org}/${new_repo}"
+        p6_github_util_repo_rename "$orig_org_repo" "$new_org_repo"
+    fi
+
+    p6_return_void
+}


### PR DESCRIPTION
+- p6_github_util_repo_archive()
+- p6_github_util_repo_patch(state)
+- p6_github_util_repo_rename(orig_org_repo, new_org_repo)
+- p6_github_util_repo_rename_strip_leading_underscores(orig_org_repo, org, repo)
+- p6_github_util_repo_unarchive()
