### PR TITLE
chore: replace curl | jq with p6_curl | p6_json_eval

### DIFF
--- a/lib/util.sh
+++ b/lib/util.sh
@@ -258,7 +258,7 @@ p6_github_util_action_version_latest() {
     local action="$1"
 
     local version
-    version=$(curl -s "https://api.github.com/repos/$action/releases/latest" | jq -r '.tag_name')
+    version=$(p6_curl -s "https://api.github.com/repos/$action/releases/latest" | p6_json_eval -r '.tag_name')
 
     p6_return_str "$version"
 }


### PR DESCRIPTION
## Summary

- Replace raw `curl | jq` with `p6_curl | p6_json_eval` in `lib/util.sh:261` for consistent logging and dry-run support

## Test plan

- [ ] `p6_github_util_action_version_latest` returns the correct tag for a known action

🤖 Generated with [Claude Code](https://claude.com/claude-code)